### PR TITLE
Fix code scanning alert no. 24: DOM text reinterpreted as HTML

### DIFF
--- a/src/_internal/bootstrap/javascript/easyui/src/jquery.tabs.js
+++ b/src/_internal/bootstrap/javascript/easyui/src/jquery.tabs.js
@@ -661,7 +661,7 @@
 				var p = tabs[i];
 				tmp.html(p.panel('options').title);
 				var title = tmp.text();
-				tmp.html(which);
+				tmp.text(which);
 				which = tmp.text();
 				if (title == which){
 					tab = p;


### PR DESCRIPTION
Fixes [https://github.com/paule32/HelpNDocTools/security/code-scanning/24](https://github.com/paule32/HelpNDocTools/security/code-scanning/24)

To fix the problem, we need to ensure that the `which` variable is properly sanitized before being used as HTML. Instead of setting `which` directly as HTML, we should use a safer method to handle the text content. We can use jQuery's `text()` method to safely set the text content, which will automatically escape any HTML characters.

- Replace the line where `which` is set as HTML with a safer alternative.
- Ensure that the `which` variable is properly sanitized before being used.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
