### PR TITLE
Potential fix for code scanning alert no. 15: Unsafe jQuery plugin

### DIFF
--- a/src/_internal/bootstrap/javascript/easyui/src/jquery.parser.js
+++ b/src/_internal/bootstrap/javascript/easyui/src/jquery.parser.js
@@ -286,6 +286,12 @@
 		}
 		
 		function _fit(target, parent, fit){
+			// Ensure parent is a jQuery object, and if a string, treat as selector, not HTML
+			if (typeof parent === 'string') {
+				parent = $(document).find(parent);
+			} else {
+				parent = $(parent);
+			}
 			if (!parent.length){return false;}
 			var t = $(target)[0];
 			var p = parent[0];


### PR DESCRIPTION
Potential fix for [https://github.com/paule32/HelpNDocTools/security/code-scanning/15](https://github.com/paule32/HelpNDocTools/security/code-scanning/15)

To fix the problem, we need to ensure that any argument (such as `parent`) that is passed to jQuery's `$()` function is not interpreted as HTML. The best way to do this is to check if the argument is a string, and if so, use `document.querySelectorAll` or `jQuery.find` to treat it strictly as a selector, not as HTML. Alternatively, we can document and enforce that only DOM elements or jQuery objects are accepted, and throw an error or ignore strings. The minimal and safest fix is to update the code in the `_size` plugin (and its helper `_fit`) so that when `parent` is used, if it is a string, it is always treated as a selector (never as HTML), or, even better, to only accept DOM elements or jQuery objects.

Specifically, in the `_fit` function, before using `parent[0]`, we should ensure that `parent` is a jQuery object or a DOM element, and never a string that could be interpreted as HTML. This can be done by checking the type of `parent` and, if it is a string, using `jQuery.find` or `document.querySelectorAll` to select elements, or by rejecting strings entirely.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
